### PR TITLE
feat: add gateway route

### DIFF
--- a/templates/api/gateway-route.yaml
+++ b/templates/api/gateway-route.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.global.includeApiGateway .Values.infra.gateway.route.enabled }}
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: {{ .Release.Name }}-gateway-route
+  labels:
+    app: sbomer-gateway
+    release: {{ .Release.Name }}
+  annotations:
+    shard: internal
+spec:
+  host: {{ .Values.infra.gateway.route.host }}
+  to:
+    kind: Service
+    name: {{ .Release.Name }}-gateway
+    weight: 100
+  wildcardPolicy: None
+  port:
+    targetPort: http
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: edge
+{{ end }}

--- a/templates/api/gateway.yaml
+++ b/templates/api/gateway.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: nginx:alpine
+          image: nginxinc/nginx-unprivileged:alpine
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
@@ -42,8 +42,16 @@ spec:
               mountPath: /etc/nginx/nginx.conf
               subPath: nginx.conf
               readOnly: true
+            - name: cache
+              mountPath: /var/cache/nginx
+            - name: run
+              mountPath: /var/run
       volumes:
         - name: config
           configMap:
             name: {{ .Release.Name }}-gateway-config
+        - name: cache
+          emptyDir: {}
+        - name: run
+          emptyDir: {}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -12,6 +12,10 @@ infra:
     storageClass: "standard"
   apicurio:
     image: quay.io/apicurio/apicurio-registry:latest
+  gateway:
+    route:
+      enabled: false
+      host: ""
 
 # --- Override Child Charts ---
 # Child components are by default looking at the Kafka and Apicurio instances set up by include flags above. 


### PR DESCRIPTION
Use nginx image that can run as non-root for OpenShift.
Add volume mounts to prevent nginx crashes on OpenShift.
Enable toggling of gateway route.