### PR TITLE
Add local Unleash instance option to helm chart

### DIFF
--- a/templates/api/gateway-config.yaml
+++ b/templates/api/gateway-config.yaml
@@ -40,21 +40,33 @@ data:
                 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             }
             
-            # --- QUARKUS ENDPOINTS FOR SBOM SERVICE (Swagger, OpenAPI, Health) ---
-            # Swagger UI
+            # --- QUARKUS ENDPOINTS FOR SBOM SERVICE ---
             location /q/swagger-ui {
                  proxy_pass http://{{ .Release.Name }}-sbom-service-chart:8080;
             }
 
-            # OpenAPI Schema (REQUIRED for Swagger UI to load data)
             location /q/openapi {
                  proxy_pass http://{{ .Release.Name }}-sbom-service-chart:8080;
             }
 
-            # 3. Health
             location /q/health {
                  proxy_pass http://{{ .Release.Name }}-sbom-service-chart:8080;
             }
+
+            # --- UNLEASH ---
+            {{- if .Values.global.includeUnleash }}
+            # Uses the same value from values.yaml
+            location {{ .Values.infra.unleash.server.basePath }}/ {
+                proxy_pass http://{{ .Release.Name }}-unleash:4242;
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                
+                proxy_http_version 1.1;
+                proxy_set_header Upgrade $http_upgrade;
+                proxy_set_header Connection "upgrade";
+            }
+            {{- end }}
 
             # --- UI (Root path) ---
             location / {

--- a/templates/unleash/unleash-db.yaml
+++ b/templates/unleash/unleash-db.yaml
@@ -1,0 +1,69 @@
+{{- if .Values.global.includeUnleash }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-unleash-db
+  labels:
+    app.kubernetes.io/name: unleash-db
+    release: {{ .Release.Name }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: unleash-db
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: unleash-db
+    spec:
+      containers:
+        - name: postgresql
+          image: {{ .Values.infra.unleash.db.image }}
+          ports:
+            - containerPort: 5432
+              name: postgres
+          env:
+            - name: POSTGRESQL_DATABASE
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-unleash-secret
+                  key: postgres-db-name
+            - name: POSTGRESQL_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-unleash-secret
+                  key: postgres-username
+            - name: POSTGRESQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-unleash-secret
+                  key: postgres-password
+          readinessProbe:
+            exec:
+              command: ["/bin/sh", "-c", "pg_isready -U $POSTGRESQL_USER -d $POSTGRESQL_DATABASE"]
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+          volumeMounts:
+            - name: db-data
+              mountPath: /var/lib/pgsql/data
+      volumes:
+        - name: db-data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-unleash-db
+  labels:
+    app.kubernetes.io/name: unleash-db
+spec:
+  type: ClusterIP
+  ports:
+    - port: 5432
+      targetPort: 5432
+      protocol: TCP
+      name: postgres
+  selector:
+    app.kubernetes.io/name: unleash-db
+{{- end }}

--- a/templates/unleash/unleash-secret.yaml
+++ b/templates/unleash/unleash-secret.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.global.includeUnleash }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-unleash-secret
+  labels:
+    app.kubernetes.io/name: unleash
+    release: {{ .Release.Name }}
+type: Opaque
+stringData:
+  # We use stringData so we don't have to base64 encode manually in the template
+  postgres-db-name: {{ .Values.infra.unleash.db.name | quote }}
+  postgres-username: {{ .Values.infra.unleash.db.username | quote }}
+  postgres-password: {{ .Values.infra.unleash.db.password | quote }}
+  api-token: {{ .Values.infra.unleash.server.apiToken | quote }}
+{{- end }}

--- a/templates/unleash/unleash.yaml
+++ b/templates/unleash/unleash.yaml
@@ -1,0 +1,77 @@
+{{- if .Values.global.includeUnleash }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-unleash
+  labels:
+    app.kubernetes.io/name: unleash
+    release: {{ .Release.Name }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: unleash
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: unleash
+    spec:
+      initContainers:
+        - name: wait-for-db
+          image: busybox
+          # Waits for the DB service to respond on port 5432
+          command: ['sh', '-c', 'until nc -z {{ .Release.Name }}-unleash-db 5432; do echo waiting for db; sleep 2; done;']
+      containers:
+        - name: unleash
+          image: {{ .Values.infra.unleash.server.image }}
+          ports:
+            - containerPort: 4242
+              name: http
+          env:
+            # Tells Unleash its public address (for UI links)
+            - name: UNLEASH_URL
+              value: {{ .Values.infra.unleash.server.externalUrl | quote }}
+            # Tells Unleash to serve assets from this subpath
+            - name: BASE_URI_PATH
+              value: {{ .Values.infra.unleash.server.basePath | quote }}
+            - name: DATABASE_HOST
+              value: {{ .Release.Name }}-unleash-db
+            - name: DATABASE_SSL
+              value: "false"
+            - name: DATABASE_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-unleash-secret
+                  key: postgres-db-name
+            - name: DATABASE_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-unleash-secret
+                  key: postgres-username
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-unleash-secret
+                  key: postgres-password
+            - name: INIT_CLIENT_API_TOKENS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-unleash-secret
+                  key: api-token
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-unleash
+  labels:
+    app.kubernetes.io/name: unleash
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.infra.unleash.server.service.port }}
+      targetPort: 4242
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: unleash
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -7,6 +7,7 @@ global:
   includeStatusDb: true
   includeS3: true
   includeMockServices: true
+  includeUnleash: true
 
 wiremock:
     # Additional configmaps for wiremock can be attached by overriding this by the parent chart
@@ -49,6 +50,24 @@ infra:
     storage:
       size: 5Gi
       persistenceEnabled: false
+  # UNLEASHED CONFIG
+  unleash:
+    db:
+      image: quay.io/fedora/postgresql-16:latest
+      name: unleash
+      username: unleash_user
+      password: unleash_password
+    server:
+      # currently from dockerhub for lack of alternatives, also since it will only be used during local development
+      image: docker.io/unleashorg/unleash-server:latest
+      # The full public URL (used for invites, reset password links, etc.)
+      externalUrl: "http://localhost:8080/unleash"
+      # The subpath where Unleash is mounted (must match your Nginx location)
+      basePath: "/unleash"
+      # Default token from your compose file
+      apiToken: "default:development.unleash-insecure-api-token" 
+      service:
+        port: 4242
 
 # --- Override Child Charts ---
 # Child components are by default looking at the Kafka and Apicurio instances set up by include flags above. 


### PR DESCRIPTION
Added a local Unleash instance option in the Helm chart so we can locally play around with it locally during implementation and testing. Seems to be nicely up and running.

Once we install the Helm chart as we usually do, we can just go into localhost:8080/unleash and log in with the default unleash admin credentials (admin-unleash4all)

Precursor to implementing the connection to it from errata-tool-handler