### PR TITLE
feat: kafka config hardening

### DIFF
--- a/templates/kafka/kafka-configmap.yaml
+++ b/templates/kafka/kafka-configmap.yaml
@@ -9,12 +9,14 @@ data:
     process.roles=controller,broker
     controller.quorum.voters=1@localhost:9094
     node.id=1
-    # Adjusted listeners for K8s (Localhost for controller, Service for clients)
-    listeners=INTERNAL://:9093,EXTERNAL://:9092,CONTROLLER://:9094
-    advertised.listeners=INTERNAL://localhost:9093,EXTERNAL://{{ .Release.Name }}-kafka:9092
-    listener.security.protocol.map=INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT,CONTROLLER:PLAINTEXT
+    # Single-broker KRaft setup for in-cluster clients.
+    # Keep one broker listener advertised via the Kubernetes Service and
+    # a separate controller listener that stays pod-local.
+    listeners=BROKER://:9092,CONTROLLER://:9094
+    advertised.listeners=BROKER://{{ .Release.Name }}-kafka:9092
+    listener.security.protocol.map=BROKER:PLAINTEXT,CONTROLLER:PLAINTEXT
     controller.listener.names=CONTROLLER
-    inter.broker.listener.name=INTERNAL
+    inter.broker.listener.name=BROKER
     offsets.topic.replication.factor=1
     group.initial.rebalance.delay.ms=0
     transaction.state.log.replication.factor=1

--- a/templates/kafka/kafka-pvc.yaml
+++ b/templates/kafka/kafka-pvc.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.global.includeKafka .Values.infra.kafka.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Release.Name }}-kafka
+  labels:
+    app: kafka
+    release: {{ .Release.Name }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  {{- if .Values.infra.kafka.storageClass }}
+  storageClassName: {{ .Values.infra.kafka.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.infra.kafka.persistence.size | quote }}
+{{- end }}

--- a/templates/kafka/kafka.yaml
+++ b/templates/kafka/kafka.yaml
@@ -57,5 +57,10 @@ spec:
           configMap:
             name: {{ .Release.Name }}-kafka-config
         - name: data
-          emptyDir: {} # Use PersistentVolumeClaim for persistence if needed
+{{- if .Values.infra.kafka.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Release.Name }}-kafka
+{{- else }}
+          emptyDir: {} # Ephemeral storage for dev deployments
+{{- end }}
 {{- end }}

--- a/templates/kafka/kafka.yaml
+++ b/templates/kafka/kafka.yaml
@@ -46,6 +46,8 @@ spec:
             - |
               /opt/kafka/bin/kafka-storage.sh format --config /opt/kafka/config/server.properties --cluster-id 'ciVofVj9T9aU1a3S-n3CBA' --ignore-formatted
               /opt/kafka/bin/kafka-server-start.sh /opt/kafka/config/server.properties
+          resources:
+            {{- toYaml .Values.infra.kafka.resources | nindent 12 }}
           volumeMounts:
             - name: config
               mountPath: /opt/kafka/config/server.properties

--- a/values.yaml
+++ b/values.yaml
@@ -37,6 +37,9 @@ infra:
   kafka:
     image: quay.io/strimzi/kafka:latest-kafka-3.7.0
     storageClass: "standard"
+    persistence:
+      enabled: false
+      size: 1Gi
 
   #Kafka UI
   kafkaUI:

--- a/values.yaml
+++ b/values.yaml
@@ -40,6 +40,12 @@ infra:
     persistence:
       enabled: false
       size: 1Gi
+    resources:
+      requests:
+        cpu: "250m"
+        memory: "512Mi"
+      limits:
+        memory: "1Gi"
 
   #Kafka UI
   kafkaUI:


### PR DESCRIPTION
Features:
- added default resource limits, default option for persistence for local dev for kafka
- naming cleanup

I looked into having our Kafka instance as an Kubernetes Operator. I deem it too complex for our dev pruposes at this stafe, but should be definitely revisited in the advanced deployment stages, as it would simplify Kafka lifecycle handling. 